### PR TITLE
Fix: Correct missing await for message statistics and persist test hi…

### DIFF
--- a/bot_statistics.py
+++ b/bot_statistics.py
@@ -50,6 +50,39 @@ async def initialize_database():
     )
     ''')
     
+    # Таблица истории тестов пользователей
+    cursor.execute('''
+    CREATE TABLE IF NOT EXISTS user_test_history (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER,
+        test_id TEXT,
+        test_date TIMESTAMP,
+        result TEXT,
+        score INTEGER,
+        FOREIGN KEY (user_id) REFERENCES users (user_id)
+    )
+    ''')
+    
+    conn.commit()
+    conn.close()
+
+# Сохранение результата теста пользователя
+async def save_test_result(user_id, test_id, test_date, result, score):
+    """Сохраняет результат пройденного теста в базу данных."""
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    
+    # Убедимся, что test_date это строка в нужном формате
+    if isinstance(test_date, datetime):
+        test_date_str = test_date.strftime("%Y-%m-%d %H:%M:%S")
+    else:
+        test_date_str = test_date # Предполагаем, что это уже строка
+        
+    cursor.execute(
+        "INSERT INTO user_test_history (user_id, test_id, test_date, result, score) VALUES (?, ?, ?, ?, ?)",
+        (user_id, test_id, test_date_str, result, score)
+    )
+    
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
…story

This commit addresses several issues:

1.  Fixes a critical bug in `psihotips_bot_updated_v6.py` where `stats.process_message` was not awaited in the general message handler. This has been corrected by using an `async lambda`.

2.  Implements persistent storage for your test history:
    - Added a `user_test_history` table to the SQLite database in `bot_statistics.py`.
    - Modified `psihotips_bot_updated_v6.py` to save test results to this table instead of an in-memory dictionary, preventing data loss on bot restart.

3.  Improves code clarity by changing single-state definitions for conversation handlers from `range(1)` to `0`.

4.  Enhances robustness in `handle_admin_reply_button` by adding an explicit `ConversationHandler.END` and logging for unexpected callback data.